### PR TITLE
Add vsock cli param

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ Create a vsock console (communication with sock file)
   --serial-path "/tmp/dbs" ;
 ```
 
+Create a virtio-vsock tunnel for Guest-to-Host communication.
+
+> When the parameter `vsock` is not given, `dbs-cli` will not add a virtio-vsock device.
+> 
+> Otherwise, `dbs-cli` will create a unix socket on the host using the argument
+> specified with the `--vsock` parameter.
+
+```
+./dbs-cli \
+  --log-file dbs-cli.log --log-level ERROR \
+  --kernel-path ~/path/to/kernel/vmlinux.bin \
+  --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" \
+  --vsock /tmp/vsock.sock;
+```
+
 # 2. Usage
 
 ## 1. Exit vm

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -170,6 +170,19 @@ pub struct CreateArgs {
         display_order = 2
     )]
     pub serial_path: String,
+
+    // The path to a vsock socket file
+    // FIXME: add more params:
+    // cid="contextid",socket_path="somepath",gid="guest_id"
+    #[clap(
+        short,
+        long,
+        value_parser,
+        default_value = "",
+        help = "Virtio VSOCK socket path",
+        display_order = 2
+    )]
+    pub vsock: String,
 }
 
 /// Config boot source including rootfs file path


### PR DESCRIPTION
Using an extra CLI parameter, we are able to specify a unix socket to be used as a VSOCK endpoint for Guest-to-Host communication.

For now, the argument is just the socket path, with a hardcoded Guest ID. The default value is empty so that the VSOCK endpoint is not added by default.

Example invocation:

./dbs-cli --kernel-path ./vmlinux \
	  --rootfs ./rootfs.img \
	  --boot-args 'console=ttyS0 tty0 pci=off root=/dev/vda' \
	  --vsock vsock.sock

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>