### PR TITLE
Introduce API Server to dbs-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -580,9 +580,9 @@ checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "os_str_bytes"
-version = "6.4.0"
+version = "6.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -73,26 +73,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "0acbd8d28a0a60d7108d7ae850af6ba34cf2d1257fc646980e5f97ce14275966"
 dependencies = [
- "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -103,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -392,12 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
 name = "heck"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,13 +405,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
+name = "hermit-abi"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "libc",
 ]
 
 [[package]]
@@ -429,6 +420,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e394faa0efb47f9f227f1cd89978f854542b318a6f64fa695489c9c993056656"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +437,18 @@ checksum = "7ba34abb5175052fc1a2227a10d2275b7386c9990167de9786c0b88d8b062330"
 dependencies = [
  "bitflags",
  "libc",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aae5bc6e2eb41c9def29a3e0f1306382807764b9b53112030eff57435667352d"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes 1.0.2",
+ "rustix 0.36.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -492,6 +505,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,7 +559,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -644,10 +663,24 @@ checksum = "2079c267b8394eb529872c3cf92e181c378b41fea36e68130357b52493701d2e"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.6.1",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.0.46",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.36.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1fbb4dfc4eb1d390c02df47760bb19a84bb80b301ecc947ab5406394d8223e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 1.0.2",
+ "libc",
+ "linux-raw-sys 0.1.3",
+ "windows-sys",
 ]
 
 [[package]]
@@ -782,12 +815,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,7 +887,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f85a7c965b8e7136952f59f2a359694c78f105b2d2ff99cf6c2c404bf7e33f"
 dependencies = [
- "rustix",
+ "rustix 0.34.8",
 ]
 
 [[package]]
@@ -961,3 +988,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,39 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -46,29 +13,6 @@ name = "arc-swap"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
-
-[[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
-
-[[package]]
-name = "async-trait"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "atty"
@@ -88,70 +32,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "backtrace"
-version = "0.3.66"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitmask-enum"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9e32d7420c85055e8107e5b2463c4eeefeaac18b52359fe9f9c08a18f342b2"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "blake3"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if 1.0.0",
- "constant_time_eq",
- "digest",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "bumpalo"
-version = "3.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
-
-[[package]]
-name = "byte-unit"
-version = "3.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
 
 [[package]]
 name = "byteorder"
@@ -180,48 +64,12 @@ name = "cc"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a284da2e6fe2092f2353e51713435363112dfd60030e22add80be333fb928f"
-dependencies = [
- "jobserver",
-]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "cgroups-rs"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3845d8ddaca63e9975f07b7a32262afe284561c2f0f620aa968913a65f671fd2"
-dependencies = [
- "libc",
- "log",
- "nix 0.24.2",
- "regex",
-]
-
-[[package]]
-name = "chrono"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-integer",
- "num-traits",
- "time 0.1.43",
- "wasm-bindgen",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -263,135 +111,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
-name = "common-path"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
-
-[[package]]
-name = "cpufeatures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
-dependencies = [
- "cfg-if 1.0.0",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
-dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97abf9f0eca9e52b7f81b945524e76710e6cb2366aead23b7d4fbf72e281f888"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc32cc5fea1d894b77d269ddb9f192110069a8a9c1f1d441195fba90553dea3"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca220e4794c934dc6b1207c3b42856ad4c302f2df1712e9f8d2eec5afaacf1f"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b846f081361125bfc8dc9d3940c84e1fd83ba54bbca7b17cd29483c828be0704"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "dashmap"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
-dependencies = [
- "cfg-if 1.0.0",
- "num_cpus",
-]
-
-[[package]]
 name = "dbs-address-space"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,7 +121,7 @@ dependencies = [
  "nix 0.23.1",
  "thiserror",
  "vm-memory",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -425,7 +144,7 @@ dependencies = [
  "libc",
  "memoffset",
  "vm-memory",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -451,7 +170,6 @@ dependencies = [
  "anyhow",
  "clap",
  "dragonball",
- "hypervisor",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
@@ -460,12 +178,13 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_derive",
+ "serde_json",
  "slog",
  "slog-json",
  "slog-scope",
  "slog-term",
  "thiserror",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -487,7 +206,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -501,17 +220,21 @@ dependencies = [
  "log",
  "serde",
  "vm-superio",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
-name = "dbs-uhttp"
-version = "0.3.1"
+name = "dbs-upcall"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd0544fe7ba81fa8deb8800843836d279a81b051e2e8ab046fe1b0cb096c1cc"
+checksum = "b2fa8b67657cd71779eaceea1b5fa989b62a1be629a07be8498417772e5a8d35"
 dependencies = [
- "libc",
- "mio",
+ "anyhow",
+ "dbs-utils",
+ "dbs-virtio-devices",
+ "log",
+ "thiserror",
+ "timerfd",
 ]
 
 [[package]]
@@ -527,7 +250,7 @@ dependencies = [
  "serde",
  "thiserror",
  "timerfd",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -542,15 +265,12 @@ dependencies = [
  "dbs-interrupt",
  "dbs-utils",
  "epoll",
- "fuse-backend-rs",
  "io-uring",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "log",
  "nix 0.23.1",
- "nydus-blobfs",
- "nydus-rafs",
  "rlimit",
  "serde",
  "serde_json",
@@ -559,18 +279,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.11.0",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
-dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -579,7 +288,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -597,7 +306,7 @@ dependencies = [
 [[package]]
 name = "dragonball"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
+source = "git+https://github.com/kata-containers/kata-containers?branch=main#6af037d37923d22e24d3299e19524b94a7629ae5"
 dependencies = [
  "arc-swap",
  "bytes",
@@ -608,6 +317,7 @@ dependencies = [
  "dbs-device",
  "dbs-interrupt",
  "dbs-legacy-devices",
+ "dbs-upcall",
  "dbs-utils",
  "dbs-virtio-devices",
  "kvm-bindings",
@@ -626,7 +336,7 @@ dependencies = [
  "thiserror",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -667,184 +377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
 dependencies = [
  "libc",
- "vmm-sys-util 0.10.0",
-]
-
-[[package]]
-name = "fail"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
-dependencies = [
- "log",
- "once_cell",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "fuse-backend-rs"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "994a3bfb694ee52bf8f3bca80d784b723f150810998219337e429cc5dbe92717"
-dependencies = [
- "arc-swap",
- "bitflags",
- "caps",
- "core-foundation-sys",
- "io-uring",
- "lazy_static",
- "libc",
- "log",
- "mio",
- "nix 0.24.2",
- "scoped-tls",
- "slab",
- "socket2",
- "tokio-uring",
- "virtio-queue",
- "vm-memory",
- "vmm-sys-util 0.10.0",
-]
-
-[[package]]
-name = "futures"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38390104763dc37a5145a53c29c63c1290b5d316d6086ec32c293f6736051bb0"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acc85df6714c176ab5edf386123fafe217be88c0840ec11f199441134a074e2"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "futures-sink"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
-
-[[package]]
-name = "futures-task"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
-
-[[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
-name = "futures-util"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -853,47 +386,9 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-
-[[package]]
-name = "glob"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "go-flag"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4a40c9ca507513f573aabaf6a8558173a1ac9aa1363d8de30c7f89b34f8d2b"
-dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "governor"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df0ee4b237afb71e99f7e2fbd840ffec2d6c4bb569f69b2af18aa1f63077d38"
-dependencies = [
- "dashmap",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot",
- "quanta",
- "rand 0.8.5",
- "smallvec",
+ "wasi",
 ]
 
 [[package]]
@@ -918,83 +413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hypervisor"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "anyhow",
- "async-trait",
- "dbs-utils",
- "dragonball",
- "go-flag",
- "kata-sys-util",
- "kata-types",
- "libc",
- "logging",
- "nix 0.24.2",
- "persist",
- "seccompiler",
- "serde",
- "serde_json",
- "slog",
- "slog-scope",
- "thiserror",
- "tokio",
- "vmm-sys-util 0.11.0",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
-dependencies = [
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "indexmap"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,15 +420,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1036,74 +445,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
-name = "jobserver"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "kata-sys-util"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "byteorder",
- "cgroups-rs",
- "chrono",
- "common-path",
- "fail",
- "kata-types",
- "lazy_static",
- "libc",
- "nix 0.24.2",
- "oci",
- "once_cell",
- "rand 0.7.3",
- "serde_json",
- "slog",
- "slog-scope",
- "subprocess",
- "thiserror",
-]
-
-[[package]]
-name = "kata-types"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "bitmask-enum",
- "byte-unit",
- "glob",
- "lazy_static",
- "num_cpus",
- "oci",
- "regex",
- "serde",
- "serde_json",
- "slog",
- "slog-scope",
- "thiserror",
- "toml",
-]
-
-[[package]]
 name = "kvm-bindings"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78c049190826fff959994b7c1d8a2930d0a348f1b8f3aa4f9bb34cd5d7f2952"
 dependencies = [
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1114,7 +461,7 @@ checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
 dependencies = [
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.11.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1128,15 +475,6 @@ name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "linux-loader"
@@ -1154,60 +492,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
-name = "lock_api"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
-
-[[package]]
-name = "logging"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "serde_json",
- "slog",
- "slog-async",
- "slog-json",
- "slog-scope",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -1219,27 +510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
-dependencies = [
- "libc",
- "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
-]
-
-[[package]]
 name = "nix"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,7 +517,7 @@ checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
 ]
@@ -1259,40 +529,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "memoffset",
-]
-
-[[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1315,155 +554,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nydus-api"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fbfbdb58ff07bed50b412d4315b3c5808979bb5decb56706ac66d53daf2cf3"
-dependencies = [
- "dbs-uhttp",
- "http",
- "lazy_static",
- "libc",
- "log",
- "mio",
- "nydus-error",
- "nydus-utils",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
- "vmm-sys-util 0.10.0",
-]
-
-[[package]]
-name = "nydus-blobfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef818ecadc217f49ce8d48506b885d8d26f877d26b0108d90d8b82547663d95"
-dependencies = [
- "fuse-backend-rs",
- "libc",
- "log",
- "nydus-error",
- "nydus-rafs",
- "nydus-storage",
- "serde",
- "serde_json",
- "vm-memory",
-]
-
-[[package]]
-name = "nydus-error"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90960fb7268286328d11f18e747bed58d8e3bbea6f401bd316e91fe39f4f7213"
-dependencies = [
- "backtrace",
- "httpdate",
- "libc",
- "log",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "nydus-rafs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a06e8b0b4a90acc2d128d2f3b1ab6ae5d325116f1f69754bd3628dbd4499f4"
-dependencies = [
- "anyhow",
- "arc-swap",
- "bitflags",
- "blake3",
- "fuse-backend-rs",
- "futures",
- "lazy_static",
- "libc",
- "log",
- "lz4-sys",
- "nix 0.24.2",
- "nydus-api",
- "nydus-error",
- "nydus-storage",
- "nydus-utils",
- "serde",
- "serde_json",
- "sha2",
- "spmc",
- "vm-memory",
-]
-
-[[package]]
-name = "nydus-storage"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5dd10c443f47a0ac7d71021f7658a605c2be5b46576a91f3238babbaf3f459e"
-dependencies = [
- "anyhow",
- "arc-swap",
- "bitflags",
- "dbs-uhttp",
- "fuse-backend-rs",
- "futures",
- "governor",
- "lazy_static",
- "libc",
- "log",
- "nix 0.24.2",
- "nydus-api",
- "nydus-error",
- "nydus-utils",
- "serde",
- "serde_json",
- "sha2",
- "tokio",
- "vm-memory",
- "vmm-sys-util 0.10.0",
-]
-
-[[package]]
-name = "nydus-utils"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7e976c67052c3ff63372e2a07701923796d25a77eac605824b26d406ab0918"
-dependencies = [
- "blake3",
- "flate2",
- "lazy_static",
- "libc",
- "log",
- "lz4-sys",
- "nix 0.24.2",
- "nydus-error",
- "serde",
- "serde_json",
- "sha2",
- "tokio",
- "zstd",
-]
-
-[[package]]
-name = "object"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "oci"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "libc",
- "serde",
- "serde_derive",
- "serde_json",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,70 +564,6 @@ name = "os_str_bytes"
 version = "6.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "persist"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "anyhow",
- "async-trait",
- "kata-sys-util",
- "kata-types",
- "libc",
- "safe-path",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro-error"
@@ -1573,108 +599,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quanta"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
-dependencies = [
- "crossbeam-utils",
- "libc",
- "mach",
- "once_cell",
- "raw-cpuid",
- "wasi 0.10.2+wasi-snapshot-preview1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.8",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6823ea29436221176fe662da99998ad3b4db2c7f31e7b6f5fe43adccd6320bb"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -1692,27 +622,10 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom",
  "redox_syscall",
  "thiserror",
 ]
-
-[[package]]
-name = "regex"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rlimit"
@@ -1722,12 +635,6 @@ checksum = "347703a5ae47adf1e693144157be231dde38c72bd485925cae7407ad3e52480b"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
@@ -1754,32 +661,6 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "safe-path"
-version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#b8dbb35bb7a5e1d99806f6992c5501c05c71aaf7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scratch"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 
 [[package]]
 name = "seccompiler"
@@ -1812,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
 dependencies = [
  "itoa",
  "ryu",
@@ -1822,42 +703,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
-dependencies = [
- "cfg-if 1.0.0",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
-name = "slab"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
-
-[[package]]
-name = "slog-async"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766c59b252e62a34651412870ff55d8c4e6d04df19b43eecb2703e417b097ffe"
-dependencies = [
- "crossbeam-channel",
- "slog",
- "take_mut",
- "thread_local",
-]
 
 [[package]]
 name = "slog-json"
@@ -1868,7 +717,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.17",
+ "time",
 ]
 
 [[package]]
@@ -1892,52 +741,14 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.17",
+ "time",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "socket2"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "spmc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "subprocess"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2e86926081dda636c546d8c5e641661049d7562a68f5488be4a1f7f66f6086"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "subtle"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1949,12 +760,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "take_mut"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "term"
@@ -2022,16 +827,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -2069,101 +864,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
-
-[[package]]
-name = "tokio"
-version = "1.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
-dependencies = [
- "autocfg",
- "libc",
- "mio",
- "num_cpus",
- "pin-project-lite",
- "socket2",
- "winapi",
-]
-
-[[package]]
-name = "tokio-uring"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3ad494f39874984d990ade7f6319dafbcd3301ff0b1841f8a55a1ebb3e742c8"
-dependencies = [
- "io-uring",
- "libc",
- "scoped-tls",
- "slab",
- "socket2",
- "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "typenum"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
-
-[[package]]
-name = "unicode-bidi"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
-
-[[package]]
-name = "url"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
 
 [[package]]
 name = "version_check"
@@ -2185,7 +889,7 @@ checksum = "519c0a333c871650269cba303bc108075d52a0c0d64f9b91fae61829b53725af"
 dependencies = [
  "log",
  "vm-memory",
- "vmm-sys-util 0.10.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -2213,16 +917,6 @@ checksum = "a4b5231d334edbc03b22704caa1a022e4c07491d6df736593f26094df8b04a51"
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
-name = "vmm-sys-util"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
@@ -2233,85 +927,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
-dependencies = [
- "cfg-if 1.0.0",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
-
-[[package]]
-name = "web-sys"
-version = "0.3.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "winapi"
@@ -2343,89 +961,3 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
-dependencies = [
- "cc",
- "libc",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main", features=["virtio-blk", "virtio-vsock", "hotplug", "dbs-upcall" ] }
-clap = { version = "3.2.14", features = ["derive"] }
+clap = { version = "4.0.27", features = ["derive"] }
 serde = "1.0.27"
 serde_derive = "1.0.27"
 libc = "0.2.39"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main" }
-hypervisor = { git = "https://github.com/kata-containers/kata-containers", branch = "main" }
+dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main", features=["virtio-blk", "virtio-vsock", "hotplug", "dbs-upcall" ] }
 clap = { version = "3.2.14", features = ["derive"] }
 serde = "1.0.27"
 serde_derive = "1.0.27"
@@ -24,3 +23,4 @@ slog = "2.7.0"
 slog-term = "2.9.0"
 slog-json = "2.6.1"
 slog-scope = "4.4.0"
+serde_json = "1.0.89"

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Create a virtio-vsock tunnel for Guest-to-Host communication.
 
 # 2. Usage
 
-## 1. Create API Server
+## 1. Create API Server and Update VM
 
 An API Server could be created by adding `--api-sock-path [socket path]`  into dbs-cli creation command.
 
-After api socket created, you could use `./dbs-cli --api-sock-path [socket path] connect` to send commands to the running VM.
+After api socket created, you could use `./dbs-cli --api-sock-path [socket path] update` to send commands to the running VM.
 
 Right now, we have only one command for cpu resizing, and here is the command example.
 
-`sudo ./dbs-cli  --api-sock-path [socket path] --vcpu-resize 2 connect`
+`sudo ./dbs-cli  --api-sock-path [socket path] --vcpu-resize 2 update`
 ## 2. Exit vm
 
 > If you want to exit vm, just input `reboot` in vm's console.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A simple example:
 ./dbs-cli \
   --kernel-path ~/path/to/kernel/vmlinux.bin \
   --rootfs ~/path/to/rootfs/rootfs.dmg \
-  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" ;
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" create ;
 ```
 
 For the rootfs from firecracker:
@@ -27,7 +27,7 @@ For the rootfs from firecracker:
 ./dbs-cli \
   --kernel-path ~/path/to/kernel/vmlinux.bin \
   --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
-  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda" ;
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda" create ;
 ```
 
 
@@ -40,7 +40,7 @@ Set the log level and log file:
   --log-file dbs-cli.log --log-level ERROR \
   --kernel-path ~/path/to/kernel/vmlinux.bin \
   --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
-  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" ;
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" create ;
 ```
 
 Create a vsock console (communication with sock file)
@@ -55,7 +55,7 @@ Create a vsock console (communication with sock file)
   --kernel-path ~/path/to/kernel/vmlinux.bin \
   --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
   --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" \
-  --serial-path "/tmp/dbs" ;
+  --serial-path "/tmp/dbs" creare;
 ```
 
 Create a virtio-vsock tunnel for Guest-to-Host communication.
@@ -71,16 +71,25 @@ Create a virtio-vsock tunnel for Guest-to-Host communication.
   --kernel-path ~/path/to/kernel/vmlinux.bin \
   --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
   --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" \
-  --vsock /tmp/vsock.sock;
+  --vsock /tmp/vsock.sock create;
 ```
 
 # 2. Usage
 
-## 1. Exit vm
+## 1. Create API Server
+
+An API Server could be created by adding `--api-sock-path [socket path]`  into dbs-cli creation command.
+
+After api socket created, you could use `./dbs-cli --api-sock-path [socket path] connect` to send commands to the running VM.
+
+Right now, we have only one command for cpu resizing, and here is the command example.
+
+`sudo ./dbs-cli  --api-sock-path [socket path] --vcpu-resize 2 connect`
+## 2. Exit vm
 
 > If you want to exit vm, just input `reboot` in vm's console.
 
-## 2. For developers
+## 3. For developers
 
 If you wish to modify some details or debug to figure out the fault of codes, you can do as follow to see whether the program act expectedly or not.
 

--- a/docs/args.md
+++ b/docs/args.md
@@ -22,3 +22,4 @@
 |     `mem-type`     |  false   |                              `shmem`                               |                Memory type that can be either hugetlbfs or shmem.                |
 |  `mem-file-path`   |  false   |                                 ``                                 |                                Memory file path.                                 |
 |   `initrd-path`    |  false   |                               `None`                               |                               The path of initrd.                                |
+|   `api-sock-path`  |  false   |                               ``                                   |                    The path of api server unix domain socket                     |

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,0 +1,38 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result};
+use serde_json::{json, Value};
+
+use crate::parser::DBSArgs;
+use std::os::unix::net::UnixStream;
+
+// src/bin/server.rs
+use std::io::Write;
+
+pub fn run_api_client(args: DBSArgs) -> Result<()> {
+    let request;
+    if let Some(vcpu_resize_num) = args.connect_args.vcpu_resize {
+        request = request_cpu_resize(vcpu_resize_num);
+        send_request(request, args.api_sock_path)?;
+    }
+
+    Ok(())
+}
+
+fn request_cpu_resize(vcpu_resize_num: usize) -> Value {
+    json!({
+        "action": "resize_vcpu",
+        "vcpu_count": vcpu_resize_num,
+    })
+}
+
+fn send_request(request: Value, api_sock_path: String) -> Result<()> {
+    let mut unix_stream = UnixStream::connect(api_sock_path).context("Could not create stream")?;
+
+    unix_stream
+        .write(request.to_string().as_bytes()) // we write bytes, &[u8]
+        .context("Failed at writing onto the unix stream")?;
+
+    Ok(())
+}

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,18 +1,17 @@
 // Copyright (C) 2022 Alibaba Cloud. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::Write;
+use std::os::unix::net::UnixStream;
+
 use anyhow::{Context, Result};
 use serde_json::{json, Value};
 
 use crate::parser::DBSArgs;
-use std::os::unix::net::UnixStream;
-
-// src/bin/server.rs
-use std::io::Write;
 
 pub fn run_api_client(args: DBSArgs) -> Result<()> {
     let request;
-    if let Some(vcpu_resize_num) = args.connect_args.vcpu_resize {
+    if let Some(vcpu_resize_num) = args.update_args.vcpu_resize {
         request = request_cpu_resize(vcpu_resize_num);
         send_request(request, args.api_sock_path)?;
     }

--- a/src/api_server.rs
+++ b/src/api_server.rs
@@ -1,0 +1,86 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex};
+
+use std::io::prelude::*;
+use std::os::unix::net::{UnixListener, UnixStream};
+
+use anyhow::{Context, Result};
+
+use crate::vmm_comm_trait::VMMComm;
+use dragonball::api::v1::{VmmRequest, VmmResponse};
+use serde_json::Value;
+
+use vmm_sys_util::eventfd::EventFd;
+
+pub struct ApiServer {
+    pub to_vmm: Option<Sender<VmmRequest>>,
+    pub from_vmm: Option<Arc<Mutex<Receiver<VmmResponse>>>>,
+    pub to_vmm_fd: EventFd,
+}
+
+impl VMMComm for ApiServer {
+    fn get_to_vmm(&self) -> Option<&Sender<VmmRequest>> {
+        self.to_vmm.as_ref()
+    }
+
+    fn get_from_vmm(&self) -> Option<Arc<Mutex<Receiver<VmmResponse>>>> {
+        self.from_vmm.clone()
+    }
+
+    fn get_to_vmm_fd(&self) -> &EventFd {
+        &self.to_vmm_fd
+    }
+}
+impl ApiServer {
+    pub fn new(
+        to_vmm: Option<Sender<VmmRequest>>,
+        from_vmm: Option<Arc<Mutex<Receiver<VmmResponse>>>>,
+        to_vmm_fd: EventFd,
+    ) -> Self {
+        ApiServer {
+            to_vmm,
+            from_vmm,
+            to_vmm_fd,
+        }
+    }
+
+    pub fn run_api_server(&mut self, api_sock_path: &str) -> Result<()> {
+        let unix_listener = UnixListener::bind(api_sock_path)?;
+        println!("dbs-cli: api server created in api_sock_path {:?}. Start waiting for connections from the client side.", api_sock_path);
+
+        // put the server logic in a loop to accept several connections
+        loop {
+            let (unix_stream, _socket_address) = unix_listener
+                .accept()
+                .context("Failed at accepting a connection on the unix listener")?;
+            self.handle_stream(unix_stream)?;
+        }
+    }
+
+    pub fn handle_stream(&mut self, mut unix_stream: UnixStream) -> Result<()> {
+        let mut message = String::new();
+        unix_stream
+            .read_to_string(&mut message)
+            .context("Failed at reading the unix stream")?;
+
+        // Parse the string of data into serde_json::Value.
+        let v: Value = serde_json::from_str(&message)?;
+
+        match v["action"].as_str() {
+            Some("resize_vcpu") => {
+                println!("mock resize vcpu (will add the actual one when vcpu resize is merged in Dragonball under Kata Container Project");
+            }
+            _ => {
+                println!("Unknown Actions");
+            }
+        }
+
+        println!("{}", message);
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,16 +6,21 @@ use std::str::FromStr;
 use std::sync::Mutex;
 
 use anyhow::Result;
+use api_client::run_api_client;
 use clap::Parser;
 use slog::Drain;
 use slog::*;
 use slog_scope::set_global_logger;
 
 use parser::run_with_cli;
+use parser::Commands;
 use parser::DBSArgs;
 
+mod api_client;
+mod api_server;
 mod cli_instance;
 mod parser;
+mod vmm_comm_trait;
 
 fn main() -> Result<()> {
     let args: DBSArgs = DBSArgs::parse();
@@ -38,6 +43,16 @@ fn main() -> Result<()> {
 
     let _guard = set_global_logger(root);
 
-    run_with_cli(args)?;
+    match args.command {
+        Some(Commands::Create) => {
+            run_with_cli(args)?;
+        }
+        Some(Commands::Connect) => {
+            run_api_client(args)?;
+        }
+        _ => {
+            panic!("Invalid command provided for dbs-cli.");
+        }
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,27 +24,25 @@ mod vmm_comm_trait;
 
 fn main() -> Result<()> {
     let args: DBSArgs = DBSArgs::parse();
-
-    let log_file = &args.log_file;
-    let log_level = Level::from_str(&args.log_level).unwrap();
-
-    let file = std::fs::OpenOptions::new()
-        .truncate(true)
-        .read(true)
-        .create(true)
-        .write(true)
-        .open(log_file)
-        .expect("Cannot write to the log file.");
-
-    let root = slog::Logger::root(
-        Mutex::new(slog_json::Json::default(file).filter_level(log_level)).map(slog::Fuse),
-        o!("version" => env!("CARGO_PKG_VERSION")),
-    );
-
-    let _guard = set_global_logger(root);
-
     match args.command {
         Some(Commands::Create) => {
+            let log_file = &args.log_file;
+            let log_level = Level::from_str(&args.log_level).unwrap();
+
+            let file = std::fs::OpenOptions::new()
+                .truncate(true)
+                .read(true)
+                .create(true)
+                .write(true)
+                .open(log_file)
+                .expect("Cannot write to the log file.");
+
+            let root = slog::Logger::root(
+                Mutex::new(slog_json::Json::default(file).filter_level(log_level)).map(slog::Fuse),
+                o!("version" => env!("CARGO_PKG_VERSION")),
+            );
+
+            let _guard = set_global_logger(root);
             run_with_cli(args)?;
         }
         Some(Commands::Connect) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
             let _guard = set_global_logger(root);
             run_with_cli(args)?;
         }
-        Some(Commands::Connect) => {
+        Some(Commands::Update) => {
             run_api_client(args)?;
         }
         _ => {

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -2,13 +2,16 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::{Args, Parser};
+use clap::{Args, Parser, Subcommand};
 use serde_derive::{Deserialize, Serialize};
 
 /// A simple command-line tool to start DragonBall micro-VM
-#[derive(Parser, Debug)]
+#[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
 pub struct DBSArgs {
+    #[clap(subcommand)]
+    pub command: Option<Commands>,
+
     #[clap(flatten)]
     pub create_args: CreateArgs,
 
@@ -20,10 +23,30 @@ pub struct DBSArgs {
 
     #[clap(long, value_parser, default_value = "Info", display_order = 1)]
     pub log_level: String,
+
+    #[clap(
+        long,
+        value_parser,
+        default_value = "",
+        help = "The path to the api server socket file (should be a unix domain socket in the host)",
+        display_order = 2
+    )]
+    pub api_sock_path: String,
+
+    #[clap(flatten)]
+    pub connect_args: ConnectArgs,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Commands {
+    /// Create Dragonball Instance
+    Create,
+    /// Connect to Dragonball Api Server (Must create a api socket when creating the Dragonball VM)
+    Connect,
 }
 
 /// CPU related configurations
-#[derive(Args, Debug, Serialize, Deserialize)]
+#[derive(Args, Debug, Serialize, Deserialize, Clone)]
 pub struct CpuTopologyArgs {
     #[clap(
         long,
@@ -63,7 +86,7 @@ pub struct CpuTopologyArgs {
 }
 
 /// Rootfs configuration
-#[derive(Args, Debug, Serialize, Deserialize)]
+#[derive(Args, Debug, Serialize, Deserialize, Clone)]
 pub struct RootfsArgs {
     #[clap(
         short,
@@ -72,7 +95,7 @@ pub struct RootfsArgs {
         help = "The path of rootfs file",
         display_order = 4
     )]
-    pub rootfs: String,
+    pub rootfs: Option<String>,
 
     #[clap(
         long,
@@ -94,7 +117,7 @@ pub struct RootfsArgs {
 }
 
 /// Configurations used for creating a VM.
-#[derive(Args, Debug, Deserialize, Serialize)]
+#[derive(Args, Debug, Deserialize, Serialize, Clone)]
 pub struct CreateArgs {
     /// features of cpu
     #[clap(
@@ -186,7 +209,7 @@ pub struct CreateArgs {
 }
 
 /// Config boot source including rootfs file path
-#[derive(Args, Debug, Deserialize, Serialize)]
+#[derive(Args, Debug, Deserialize, Serialize, Clone)]
 #[clap(arg_required_else_help = true)]
 pub struct BootArgs {
     #[clap(
@@ -196,7 +219,7 @@ pub struct BootArgs {
         help = "The path of kernel image (Only uncompressed kernel is supported for Dragonball)",
         display_order = 1
     )]
-    pub kernel_path: String,
+    pub kernel_path: Option<String>,
 
     #[clap(
         short,
@@ -221,4 +244,15 @@ pub struct BootArgs {
     /// rootfs
     #[clap(flatten)]
     pub rootfs_args: RootfsArgs,
+}
+
+#[derive(Args, Debug, Serialize, Deserialize, Clone)]
+pub struct ConnectArgs {
+    #[clap(
+        long,
+        value_parser,
+        help = "Resize Vcpu through connection with dbs-cli api server",
+        display_order = 2
+    )]
+    pub vcpu_resize: Option<usize>,
 }

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -34,15 +34,15 @@ pub struct DBSArgs {
     pub api_sock_path: String,
 
     #[clap(flatten)]
-    pub connect_args: ConnectArgs,
+    pub update_args: UpdateArgs,
 }
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum Commands {
     /// Create Dragonball Instance
     Create,
-    /// Connect to Dragonball Api Server (Must create a api socket when creating the Dragonball VM)
-    Connect,
+    /// Connect to Dragonball Api Server and update the Dragonball VM (Must create a api socket when creating the Dragonball VM)
+    Update,
 }
 
 /// CPU related configurations
@@ -247,7 +247,7 @@ pub struct BootArgs {
 }
 
 #[derive(Args, Debug, Serialize, Deserialize, Clone)]
-pub struct ConnectArgs {
+pub struct UpdateArgs {
     #[clap(
         long,
         value_parser,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -11,9 +11,11 @@ use std::{
 
 use anyhow::Result;
 
+pub use args::Commands;
 pub use args::DBSArgs;
 use dragonball::{api::v1::VmmService, Vmm};
 
+use crate::api_server::ApiServer;
 use crate::cli_instance::CliInstance;
 
 pub mod args;
@@ -31,7 +33,7 @@ pub fn run_with_cli(args: DBSArgs) -> Result<i32> {
     let vmm_service = VmmService::new(from_runtime, to_runtime);
 
     cli_instance.to_vmm = Some(to_vmm);
-    cli_instance.from_vmm = Some(from_vmm);
+    cli_instance.from_vmm = Some(Arc::new(Mutex::new(from_vmm)));
 
     let api_event_fd2 = cli_instance
         .to_vmm_fd
@@ -46,14 +48,39 @@ pub fn run_with_cli(args: DBSArgs) -> Result<i32> {
     )
     .expect("Failed to start vmm");
 
+    let api_event_fd3 = cli_instance
+        .to_vmm_fd
+        .try_clone()
+        .expect("Failed to dup eventfd");
+
+    let mut api_server = ApiServer::new(
+        cli_instance.to_vmm.clone(),
+        cli_instance.from_vmm.clone(),
+        api_event_fd3,
+    );
+
+    // clone the arguments for other thread to use
+    let clone_args = args.clone();
     thread::Builder::new()
-        .name("set configuration".to_owned())
+        .name("set_cfg".to_owned())
         .spawn(move || {
             cli_instance
-                .run_vmm_server(args)
+                .run_vmm_server(clone_args)
                 .expect("Failed to run server.");
         })
         .unwrap();
+
+    println!("[CHAOTEST] 2");
+    if !args.api_sock_path.is_empty() {
+        thread::Builder::new()
+            .name("api_server".to_owned())
+            .spawn(move || {
+                api_server
+                    .run_api_server(&args.api_sock_path)
+                    .expect("Failed to api server.");
+            })
+            .unwrap();
+    }
 
     Ok(Vmm::run_vmm_event_loop(
         Arc::new(Mutex::new(vmm)),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -70,7 +70,6 @@ pub fn run_with_cli(args: DBSArgs) -> Result<i32> {
         })
         .unwrap();
 
-    println!("[CHAOTEST] 2");
     if !args.api_sock_path.is_empty() {
         thread::Builder::new()
             .name("api_server".to_owned())

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -1,0 +1,126 @@
+use std::sync::mpsc::{Receiver, Sender};
+use vmm_sys_util::eventfd::EventFd;
+
+use anyhow::{anyhow, Context, Result};
+use std::sync::{Arc, Mutex};
+
+use dragonball::{
+    api::v1::{
+        BlockDeviceConfigInfo, BootSourceConfig, VmmAction, VmmActionError, VmmData, VmmRequest,
+        VmmResponse, VsockDeviceConfigInfo,
+    },
+    vm::VmConfigInfo,
+};
+
+pub enum Request {
+    Sync(VmmAction),
+}
+
+const REQUEST_RETRY: u32 = 500;
+
+pub trait VMMComm {
+    // Method signatures; these will return a string.
+    fn get_to_vmm(&self) -> Option<&Sender<VmmRequest>>;
+    fn get_from_vmm(&self) -> Option<Arc<Mutex<Receiver<VmmResponse>>>>;
+    fn get_to_vmm_fd(&self) -> &EventFd;
+
+    fn handle_request(&self, req: Request) -> Result<VmmData> {
+        let Request::Sync(vmm_action) = req;
+        match self.send_request(vmm_action) {
+            Ok(vmm_outcome) => match *vmm_outcome {
+                Ok(vmm_data) => Ok(vmm_data),
+                Err(vmm_action_error) => Err(anyhow!("vmm action error: {:?}", vmm_action_error)),
+            },
+            Err(e) => Err(e),
+        }
+    }
+
+    fn send_request(&self, vmm_action: VmmAction) -> Result<VmmResponse> {
+        if let Some(to_vmm) = self.get_to_vmm() {
+            to_vmm
+                .send(Box::new(vmm_action.clone()))
+                .with_context(|| format!("Failed to send  {:?} via channel ", vmm_action))?;
+        } else {
+            return Err(anyhow!("to_vmm is None"));
+        }
+
+        //notify vmm action
+        if let Err(e) = self.get_to_vmm_fd().write(1) {
+            return Err(anyhow!("failed to notify vmm: {}", e));
+        }
+
+        if let Some(from_vmm) = self.get_from_vmm().as_ref() {
+            match from_vmm.lock().unwrap().recv() {
+                Err(e) => Err(anyhow!("vmm recv err: {}", e)),
+                Ok(vmm_outcome) => Ok(vmm_outcome),
+            }
+        } else {
+            Err(anyhow!("from_vmm is None"))
+        }
+    }
+    fn handle_request_with_retry(&self, req: Request) -> Result<VmmData> {
+        let Request::Sync(vmm_action) = req;
+        for _ in 0..REQUEST_RETRY {
+            match self.send_request(vmm_action.clone()) {
+                Ok(vmm_outcome) => match *vmm_outcome {
+                    Ok(vmm_data) => {
+                        return Ok(vmm_data);
+                    }
+                    Err(vmm_action_error) => {
+                        if let VmmActionError::UpcallNotReady = vmm_action_error {
+                            std::thread::sleep(std::time::Duration::from_millis(10));
+                            continue;
+                        } else {
+                            return Err(vmm_action_error.into());
+                        }
+                    }
+                },
+                Err(err) => {
+                    return Err(err);
+                }
+            }
+        }
+        Err(anyhow::anyhow!(
+            "After {} attempts, it still doesn't work.",
+            REQUEST_RETRY
+        ))
+    }
+
+    fn put_boot_source(&self, boot_source_cfg: BootSourceConfig) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::ConfigureBootSource(
+            boot_source_cfg,
+        )))
+        .context("Failed to configure boot source")?;
+        Ok(())
+    }
+
+    fn instance_start(&self) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::StartMicroVm))
+            .context("Failed to start MicroVm")?;
+        Ok(())
+    }
+
+    fn insert_block_device(&self, device_cfg: BlockDeviceConfigInfo) -> Result<()> {
+        self.handle_request_with_retry(Request::Sync(VmmAction::InsertBlockDevice(
+            device_cfg.clone(),
+        )))
+        .with_context(|| format!("Failed to insert block device {:?}", device_cfg))?;
+        Ok(())
+    }
+
+    fn set_vm_configuration(&self, vm_config: VmConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::SetVmConfiguration(
+            vm_config.clone(),
+        )))
+        .with_context(|| format!("Failed to set vm configuration {:?}", vm_config))?;
+        Ok(())
+    }
+
+    fn insert_vsock(&self, vsock_cfg: VsockDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertVsockDevice(
+            vsock_cfg.clone(),
+        )))
+        .with_context(|| format!("Failed to insert vsock device {:?}", vsock_cfg))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
```

    cli: add api server
    
    api server and api client are added to the dbs-cli. Through API server,
    users could send commands when VM is running, so that we could use
    dbs-cli to test operations like device hotplug.
    
    Besides, since api_server and cli_instance share lots of common
    functions so a new trait VmmComm is introduced to decreate the
    repetitive rate of the same code.
    More information could be found in README file and args.md.
    
    Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>
```

```
log: set up log only when command is create
    
    Since now we have 2 commands, we should only set up log only when
    command is create so that when the command is connect the previous log
    won't get flushed.
    
    Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>
```