### PR TITLE
Add support to insert virtio-net devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 [[package]]
 name = "dragonball"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#dc42f0a33b4e60750cda9aba241d25a88cbc65c2"
+source = "git+https://github.com/kata-containers/kata-containers?branch=main#ee5dda012b3a8dca08eb1eea32ddac37b5355fd6"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main", features=["virtio-blk", "virtio-vsock", "hotplug", "dbs-upcall" ] }
+dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main", features = [
+    "virtio-blk",
+    "virtio-vsock",
+    "virtio-net",
+    "hotplug",
+    "dbs-upcall",
+] }
 clap = { version = "4.0.27", features = ["derive"] }
 serde = "1.0.27"
 serde_derive = "1.0.27"
@@ -26,4 +32,3 @@ slog-scope = "4.4.0"
 slog-stdlog = "4.1.1"
 serde_json = "1.0.89"
 crossbeam-channel = "0.5.6"
-

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ Create a virtio-vsock tunnel for Guest-to-Host communication.
   --vsock /tmp/vsock.sock create;
 ```
 
+Create virtio-net devices.
+
+> The type of the `--virnets` receives an array of VirtioNetDeviceConfigInfo in the
+> format of JSON.
+
+```
+./dbs-cli \
+  --log-file dbs-cli.log --log-level ERROR \
+  --kernel-path ~/path/to/kernel/vmlinux.bin \
+  --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" \
+  --virnets "[{\"iface_id\":\"eth0\",\"host_dev_name\":\"tap0\",\"num_queues\":2,\"queue_size\":0,\"guest_mac\":\"43:2D:9C:13:71:48\",\"allow_duplicate_mac\":true}]" \
+  create;
+```
+
 # 2. Usage
 
 ## 1. Create API Server and Update VM
@@ -85,6 +100,19 @@ After api socket created, you could use `./dbs-cli --api-sock-path [socket path]
 Right now, we have only one command for cpu resizing, and here is the command example.
 
 `sudo ./dbs-cli  --api-sock-path [socket path] --vcpu-resize 2 update`
+
+Create hot-plug virtio-net devices via API Server.
+
+> The type of the `--hotplug-virnets` receives an array of
+> VirtioNetDeviceConfigInfo in the format of JSON.
+
+```
+sudo ./dbs-cli  \
+  --api-sock-path [socket path]
+  --hotplug-virnets "[{\"iface_id\":\"eth0\",\"host_dev_name\":\"tap0\",\"num_queues\":2,\"queue_size\":0,\"guest_mac\":\"43:2D:9C:13:71:48\",\"allow_duplicate_mac\":true}]" \
+  update
+```
+
 ## 2. Exit vm
 
 > If you want to exit vm, just input `reboot` in vm's console.

--- a/src/cli_instance.rs
+++ b/src/cli_instance.rs
@@ -20,6 +20,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, InstanceInfo, VmmRequest, VmmResponse,
         VsockDeviceConfigInfo,
     },
+    device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vm::{CpuTopology, VmConfigInfo},
 };
 
@@ -152,6 +153,16 @@ impl CliInstance {
             // set vsock
             self.insert_vsock(vsock_config_info)
                 .expect("failed to set vsock socket path");
+        }
+
+        if !args.create_args.virnets.is_empty() {
+            let configs: Vec<VirtioNetDeviceConfigInfo> =
+                serde_json::from_str(&args.create_args.virnets)
+                    .expect("failed to parse virtio-net devices from JSON");
+            for config in configs.into_iter() {
+                self.insert_virnet(config)
+                    .expect("failed to insert a virtio-net device");
+            }
         }
 
         // start micro-vm

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -206,6 +206,17 @@ pub struct CreateArgs {
         display_order = 2
     )]
     pub vsock: String,
+
+    #[clap(
+        long,
+        value_parser,
+        default_value = "",
+        help = r#"Insert virtio-net devices into the Dragonball. 
+The type of it is an array of VirtioNetDeviceConfigInfo, e.g.
+    --virnets '[{"iface_id":"eth0","host_dev_name":"tap0","num_queues":2,"queue_size":0,"allow_duplicate_mac":true}]'"#,
+        display_order = 2
+    )]
+    pub virnets: String,
 }
 
 /// Config boot source including rootfs file path
@@ -255,4 +266,13 @@ pub struct UpdateArgs {
         display_order = 2
     )]
     pub vcpu_resize: Option<usize>,
+    #[clap(
+        long,
+        value_parser,
+        help = r#"Insert hotplug virtio-net devices into the Dragonball. 
+The type of it is an array of VirtioNetDeviceConfigInfo, e.g.
+    --hotplug-virnets '[{"iface_id":"eth0","host_dev_name":"tap0","num_queues":2,"queue_size":0,"allow_duplicate_mac":true}]'"#,
+        display_order = 2
+    )]
+    pub hotplug_virnets: Option<String>,
 }

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -9,6 +9,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, VmmAction, VmmActionError, VmmData, VmmRequest,
         VmmResponse, VsockDeviceConfigInfo,
     },
+    device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vcpu::VcpuResizeInfo,
     vm::VmConfigInfo,
 };
@@ -130,6 +131,12 @@ pub trait VMMComm {
             resize_vcpu_cfg.clone(),
         )))
         .with_context(|| format!("Failed to resize vcpu {resize_vcpu_cfg:?}"))?;
+        Ok(())
+    }
+
+    fn insert_virnet(&self, config: VirtioNetDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertNetworkDevice(config)))
+            .context("Request to insert a virtio-net device")?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR gives the users two ways to insert virtio-net devices:

1. Insert before VMM launched. The parameter is 
    `--virnets '[{"iface_id":"eth0","host_dev_name":"tap0","num_queues":2,"queue_size":0,"allow_duplicate_mac":true}]'`. 
2. Insert hotplug devices after VMM launched. The parameter is
    `--hotplug-virnets '[{"iface_id":"eth0","host_dev_name":"tap0","num_queues":2,"queue_size":0,"allow_duplicate_mac":true}]'`
    
Both of these parameters receive an array of VirtioNetDeviceConfigInfo in the
format of JSON to make them more configurable.

Fixes: #15

Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>