### PR TITLE
cli: add support to insert virtio-fs devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,7 @@ dependencies = [
  "dbs-interrupt",
  "dbs-utils",
  "epoll",
+ "fuse-backend-rs",
  "io-uring",
  "kvm-bindings",
  "kvm-ioctls",
@@ -572,6 +573,7 @@ dependencies = [
  "mio",
  "nix 0.24.3",
  "tokio-uring",
+ "virtio-queue",
  "vm-memory",
  "vmm-sys-util 0.10.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 dragonball = { git = "https://github.com/kata-containers/kata-containers", branch = "main", features = [
     "virtio-blk",
+    "virtio-fs",
     "virtio-vsock",
     "virtio-net",
     "hotplug",

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -22,6 +22,10 @@ pub fn run_api_client(args: DBSArgs) -> Result<()> {
         let request = request_virtio_blk(&config);
         send_request(request, &args.api_sock_path)?;
     }
+    if let Some(config) = args.update_args.patch_fs {
+        let request = request_patch_fs(&config);
+        send_request(request, &args.api_sock_path)?;
+    }
     Ok(())
 }
 
@@ -45,6 +49,13 @@ fn request_virtio_blk(virtio_blk_config: &str) -> Value {
     json!({
         "action": "insert_virblks",
         "config": virtio_blk_config,
+    })
+}
+
+fn request_patch_fs(patch_fs_config: &str) -> Value {
+    json!({
+        "action": "patch_fs",
+        "config": patch_fs_config,
     })
 }
 

--- a/src/api_server.rs
+++ b/src/api_server.rs
@@ -10,6 +10,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{anyhow, Context, Result};
 use dragonball::device_manager::blk_dev_mgr::BlockDeviceConfigInfo;
+use dragonball::device_manager::fs_dev_mgr::FsMountConfigInfo;
 use dragonball::device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo;
 
 use crate::vmm_comm_trait::VMMComm;
@@ -104,6 +105,16 @@ impl ApiServer {
                     self.insert_virblk(config.clone())
                         .context("Insert a virtio-blk device to the Dragonball")?;
                 }
+            }
+            Some("patch_fs") => {
+                let config_json = match v["config"].as_str() {
+                    Some(config_json) => config_json,
+                    None => return Err(anyhow!("The config of patch fs is required")),
+                };
+                let config: FsMountConfigInfo =
+                    serde_json::from_str(config_json).context("Parse patch fs config from json")?;
+                self.patch_fs(config)
+                    .context("Insert a patch fs to the Dragonball")?;
             }
             _ => {
                 println!("Unknown Actions");

--- a/src/cli_instance.rs
+++ b/src/cli_instance.rs
@@ -20,6 +20,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, InstanceInfo, VmmRequest, VmmResponse,
         VsockDeviceConfigInfo,
     },
+    device_manager::fs_dev_mgr::FsDeviceConfigInfo,
     device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vm::{CpuTopology, VmConfigInfo},
 };
@@ -173,6 +174,13 @@ impl CliInstance {
                 self.insert_virblk(config)
                     .expect("failed to insert a virtio-blk device");
             }
+        }
+
+        if !args.create_args.fs.is_empty() {
+            let fs_config: FsDeviceConfigInfo = serde_json::from_str(&args.create_args.fs)
+                .expect("failed to parse virtio-fs devices from JSON");
+            self.insert_fs(fs_config)
+                .expect("failed to insert a virtio-fs device");
         }
 
         // start micro-vm

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -228,6 +228,15 @@ The type of it is an array of BlockDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub virblks: String,
+
+    #[clap(
+        long,
+        value_parser,
+        default_value = "",
+        help = r#"Insert virtio-fs devices into the Dragonball using the FsDeviceConfigInfo."#,
+        display_order = 2
+    )]
+    pub fs: String,
 }
 
 /// Config boot source including rootfs file path
@@ -297,4 +306,12 @@ The type of it is an array of BlockDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub hotplug_virblks: Option<String>,
+
+    #[clap(
+        long,
+        value_parser,
+        help = r#"attach or detach a virtiofs backend fs using the FsMountConfig."#,
+        display_order = 2
+    )]
+    pub patch_fs: Option<String>,
 }

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -9,6 +9,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, VmmAction, VmmActionError, VmmData, VmmRequest,
         VmmResponse, VsockDeviceConfigInfo,
     },
+    device_manager::fs_dev_mgr::{FsDeviceConfigInfo, FsMountConfigInfo},
     device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vcpu::VcpuResizeInfo,
     vm::VmConfigInfo,
@@ -143,6 +144,23 @@ pub trait VMMComm {
     fn insert_virblk(&self, blk_cfg: BlockDeviceConfigInfo) -> Result<()> {
         self.handle_request(Request::Sync(VmmAction::InsertBlockDevice(blk_cfg.clone())))
             .with_context(|| format!("Failed to insert virtio-blk device {:?}", blk_cfg))?;
+        Ok(())
+    }
+
+    fn insert_fs(&self, fs_cfg: FsDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertFsDevice(fs_cfg.clone())))
+            .with_context(|| format!("Failed to insert {} fs device {:?}", fs_cfg.mode, fs_cfg))?;
+        Ok(())
+    }
+
+    fn patch_fs(&self, cfg: FsMountConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::ManipulateFsBackendFs(cfg.clone())))
+            .with_context(|| {
+                format!(
+                    "Failed to {:?} backend {:?} at {} mount config {:?}",
+                    cfg.ops, cfg.fstype, cfg.mountpoint, cfg
+                )
+            })?;
         Ok(())
     }
 }


### PR DESCRIPTION
This PR gives the users a way to insert virtio-fs devices:

1. Insert device before VMM launched. The parameter is --fs '{
    "sock_path":"",
    "tag":"myfs",
    "num_queues":1,
    "queue_size":1024,
    "cache_size":0,
    "thread_pool_size":1,
    "cache_policy":"auto",
    "writeback_cache":true,
    "no_open":true,
    "xattr":true,
    "drop_sys_resource":false,
    "mode":"virtio",
    "fuse_killpriv_v2":true,
    "no_readdir":false
}'

2. Attatch a backend fs after VMM launched. The parameter is --patch-fs '{
    "ops":"mount",
    "fstype":"passthroughfs",
    "source":"/tmp",
    "mountpoint":"/mnt",
    "tag":"myfs"
}'