### PR TITLE
Add support to insert virtio-blk devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ Create virtio-net devices.
   create;
 ```
 
+Create virtio-blk devices.
+
+> The type of the `--virblks` receives an array of BlockDeviceConfigInfo in the
+> format of JSON.
+
+```
+./dbs-cli \
+  --log-file dbs-cli.log --log-level ERROR \
+  --kernel-path ~/path/to/kernel/vmlinux.bin \
+  --rootfs ~/path/to/rootfs/bionic.rootfs.ext4 \
+  --boot-args "console=ttyS0 tty0 reboot=k debug panic=1 pci=off root=/dev/vda1" \
+  --virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]' \
+  create;
+```
+
 # 2. Usage
 
 ## 1. Create API Server and Update VM
@@ -110,6 +125,18 @@ Create hot-plug virtio-net devices via API Server.
 sudo ./dbs-cli  \
   --api-sock-path [socket path]
   --hotplug-virnets "[{\"iface_id\":\"eth0\",\"host_dev_name\":\"tap0\",\"num_queues\":2,\"queue_size\":0,\"guest_mac\":\"43:2D:9C:13:71:48\",\"allow_duplicate_mac\":true}]" \
+  update
+```
+
+Create hot-plug virtio-blk devices via API Server.
+
+> The type of the `--hotplug-virblks` receives an array of
+> BlockDeviceConfigInfo in the format of JSON.
+
+```
+sudo ./dbs-cli  \
+  --api-sock-path [socket path]
+  --hotplug-virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]' \
   update
 ```
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -18,6 +18,10 @@ pub fn run_api_client(args: DBSArgs) -> Result<()> {
         let request = request_virtio_net(&config);
         send_request(request, &args.api_sock_path)?;
     }
+    if let Some(config) = args.update_args.hotplug_virblks {
+        let request = request_virtio_blk(&config);
+        send_request(request, &args.api_sock_path)?;
+    }
     Ok(())
 }
 
@@ -33,6 +37,14 @@ fn request_virtio_net(virtio_net_config: &str) -> Value {
     json!({
         "action": "insert_virnets",
         "config": virtio_net_config,
+    })
+}
+
+/// Insert virtio-blk devices
+fn request_virtio_blk(virtio_blk_config: &str) -> Value {
+    json!({
+        "action": "insert_virblks",
+        "config": virtio_blk_config,
     })
 }
 

--- a/src/api_server.rs
+++ b/src/api_server.rs
@@ -9,6 +9,7 @@ use std::io::prelude::*;
 use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{anyhow, Context, Result};
+use dragonball::device_manager::blk_dev_mgr::BlockDeviceConfigInfo;
 use dragonball::device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo;
 
 use crate::vmm_comm_trait::VMMComm;
@@ -90,6 +91,18 @@ impl ApiServer {
                 for config in configs.iter() {
                     self.insert_virnet(config.clone())
                         .context("Insert a virtio-net device to the Dragonball")?;
+                }
+            }
+            Some("insert_virblks") => {
+                let config_json = match v["config"].as_str() {
+                    Some(config_json) => config_json,
+                    None => return Err(anyhow!("The config of virtio-blk device is required")),
+                };
+                let configs: Vec<BlockDeviceConfigInfo> = serde_json::from_str(config_json)
+                    .context("Parse virtio-blk device config from json")?;
+                for config in configs.iter() {
+                    self.insert_virblk(config.clone())
+                        .context("Insert a virtio-blk device to the Dragonball")?;
                 }
             }
             _ => {

--- a/src/cli_instance.rs
+++ b/src/cli_instance.rs
@@ -165,6 +165,16 @@ impl CliInstance {
             }
         }
 
+        if !args.create_args.virblks.is_empty() {
+            let configs: Vec<BlockDeviceConfigInfo> =
+                serde_json::from_str(&args.create_args.virblks)
+                    .expect("failed to parse virtio-blk devices from JSON");
+            for config in configs.into_iter() {
+                self.insert_virblk(config)
+                    .expect("failed to insert a virtio-blk device");
+            }
+        }
+
         // start micro-vm
         self.instance_start().expect("failed to start micro-vm");
 

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -217,6 +217,17 @@ The type of it is an array of VirtioNetDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub virnets: String,
+
+    #[clap(
+        long,
+        value_parser,
+        default_value = "",
+        help = r#"Insert virtio-blk devices into the Dragonball.
+The type of it is an array of BlockDeviceConfigInfo, e.g.
+    --virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]'"#,
+        display_order = 2
+    )]
+    pub virblks: String,
 }
 
 /// Config boot source including rootfs file path
@@ -266,6 +277,7 @@ pub struct UpdateArgs {
         display_order = 2
     )]
     pub vcpu_resize: Option<usize>,
+
     #[clap(
         long,
         value_parser,
@@ -275,4 +287,14 @@ The type of it is an array of VirtioNetDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub hotplug_virnets: Option<String>,
+
+    #[clap(
+        long,
+        value_parser,
+        help = r#"Insert virtio-blk devices into the Dragonball.
+The type of it is an array of BlockDeviceConfigInfo, e.g.
+    --hotplug-virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]'"#,
+        display_order = 2
+    )]
+    pub hotplug_virblks: Option<String>,
 }

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -139,4 +139,10 @@ pub trait VMMComm {
             .context("Request to insert a virtio-net device")?;
         Ok(())
     }
+
+    fn insert_virblk(&self, blk_cfg: BlockDeviceConfigInfo) -> Result<()> {
+        self.handle_request(Request::Sync(VmmAction::InsertBlockDevice(blk_cfg.clone())))
+            .with_context(|| format!("Failed to insert virtio-blk device {:?}", blk_cfg))?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
This PR gives the users two ways to insert virtio-blk devices:

1. Insert before VMM launched. The parameter is `--virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]'`.

2. Insert hotplug devices after VMM launched. The parameter is `--hotplug-virblks '[{"drive_id":"testblk","device_type":"RawBlock","path_on_host":"/path/to/test.img","is_root_device":false,"is_read_only":false,"is_direct":false,"no_drop":false,"num_queues":1,"queue_size":1024}]'`

Both of these parameters receive an array of BlockDeviceConfigInfo in the format of JSON to make them more configurable.

Fixes: openanolis#19