### PR TITLE
Support memory update in dbs-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,11 +246,12 @@ dependencies = [
 
 [[package]]
 name = "dbs-address-space"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcc37dc0b8ffae1c5911d13ae630dc7a9020fa0de0edd178d6ab71daf56c8fc"
+checksum = "95e20d28a9cd13bf00d0ecd1bd073d242242b04f0acb663d7adfc659f8879322"
 dependencies = [
  "arc-swap",
+ "lazy_static",
  "libc",
  "nix 0.23.2",
  "thiserror",
@@ -284,9 +285,9 @@ dependencies = [
 
 [[package]]
 name = "dbs-boot"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a74a8c05a1674d3032e610b4f201c7440c345559bad3dfe6b455ce195785108"
+checksum = "5466a92f75aa928a9103dcb2088f6d1638ef9da8945fad7389a73864dfa0182c"
 dependencies = [
  "dbs-arch",
  "kvm-bindings",
@@ -363,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "dbs-upcall"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699e62afa444ae4b00d474fd91bc37785ba050acdfbe179731c81898e32efc3f"
+checksum = "ea3a78128fd0be8b8b10257675c262b378dc5d00b1e18157736a6c27e45ce4fb"
 dependencies = [
  "anyhow",
  "dbs-utils",
@@ -393,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "dbs-virtio-devices"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e5c6c48b766afb95851b04b6b193871a59d0b2a3ed19990d4f8f651ae5c668"
+checksum = "24d671cc3e5f98b84ef6b6bed007d28f72f16d3aea8eb38e2d42b00b2973c1d8"
 dependencies = [
  "byteorder",
  "caps",
@@ -408,7 +409,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "log",
- "nix 0.23.2",
+ "nix 0.24.3",
  "nydus-api",
  "nydus-blobfs",
  "nydus-rafs",
@@ -458,7 +459,7 @@ dependencies = [
 [[package]]
 name = "dragonball"
 version = "0.1.0"
-source = "git+https://github.com/kata-containers/kata-containers?branch=main#ee5dda012b3a8dca08eb1eea32ddac37b5355fd6"
+source = "git+https://github.com/kata-containers/kata-containers?branch=main#29885533050d133df86d06edc1a5ee8825129f1f"
 dependencies = [
  "arc-swap",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ dragonball = { git = "https://github.com/kata-containers/kata-containers", branc
     "virtio-blk",
     "virtio-vsock",
     "virtio-net",
+    "virtio-mem",
     "hotplug",
     "dbs-upcall",
+    "atomic-guest-memory"
 ] }
 clap = { version = "4.0.27", features = ["derive"] }
 serde = "1.0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ dragonball = { git = "https://github.com/kata-containers/kata-containers", branc
     "virtio-vsock",
     "virtio-net",
     "virtio-mem",
+    "virtio-balloon",
     "hotplug",
     "dbs-upcall",
     "atomic-guest-memory"

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -27,6 +27,11 @@ pub fn run_api_client(args: DBSArgs) -> Result<()> {
         send_request(request, &args.api_sock_path)?;
     }
 
+    if let Some(size_mib) = args.update_args.balloon_memory {
+        let request = request_balloon_memory(size_mib);
+        send_request(request, &args.api_sock_path)?;
+    }
+
     Ok(())
 }
 
@@ -56,6 +61,13 @@ fn request_virtio_blk(virtio_blk_config: &str) -> Value {
 fn request_hotplug_memory(size_mib: usize) -> Value {
     json!({
         "action": "hotplug_memory",
+        "size_mib": size_mib,
+    })
+}
+
+fn request_balloon_memory(size_mib: usize) -> Value {
+    json!({
+        "action": "balloon_memory",
         "size_mib": size_mib,
     })
 }

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -22,6 +22,11 @@ pub fn run_api_client(args: DBSArgs) -> Result<()> {
         let request = request_virtio_blk(&config);
         send_request(request, &args.api_sock_path)?;
     }
+    if let Some(size_mib) = args.update_args.hotplug_memory {
+        let request = request_hotplug_memory(size_mib);
+        send_request(request, &args.api_sock_path)?;
+    }
+
     Ok(())
 }
 
@@ -45,6 +50,13 @@ fn request_virtio_blk(virtio_blk_config: &str) -> Value {
     json!({
         "action": "insert_virblks",
         "config": virtio_blk_config,
+    })
+}
+
+fn request_hotplug_memory(size_mib: usize) -> Value {
+    json!({
+        "action": "hotplug_memory",
+        "size_mib": size_mib,
     })
 }
 

--- a/src/api_server.rs
+++ b/src/api_server.rs
@@ -9,6 +9,7 @@ use std::io::prelude::*;
 use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{anyhow, Context, Result};
+use dragonball::device_manager::balloon_dev_mgr::BalloonDeviceConfigInfo;
 use dragonball::device_manager::blk_dev_mgr::BlockDeviceConfigInfo;
 use dragonball::device_manager::mem_dev_mgr::MemDeviceConfigInfo;
 use dragonball::device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo;
@@ -120,6 +121,20 @@ impl ApiServer {
                     use_shared_irq: None,
                 };
                 return self.insert_mem_device(mem_cfg);
+            }
+            Some("balloon_memory") => {
+                let balloon_cfg = BalloonDeviceConfigInfo {
+                    balloon_id: "virtio-balloon0".to_string(),
+                    size_mib: v["size_mib"]
+                        .as_u64()
+                        .context("Invalid virtio-balloon size input")?,
+                    use_generic_irq: None,
+                    use_shared_irq: None,
+                    f_deflate_on_oom: false,
+                    // TODO: enable free page reporting
+                    f_reporting: false,
+                };
+                return self.insert_balloon_device(balloon_cfg);
             }
             _ => {
                 println!("Unknown Actions");

--- a/src/api_server.rs
+++ b/src/api_server.rs
@@ -10,6 +10,7 @@ use std::os::unix::net::{UnixListener, UnixStream};
 
 use anyhow::{anyhow, Context, Result};
 use dragonball::device_manager::blk_dev_mgr::BlockDeviceConfigInfo;
+use dragonball::device_manager::mem_dev_mgr::MemDeviceConfigInfo;
 use dragonball::device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo;
 
 use crate::vmm_comm_trait::VMMComm;
@@ -104,6 +105,21 @@ impl ApiServer {
                     self.insert_virblk(config.clone())
                         .context("Insert a virtio-blk device to the Dragonball")?;
                 }
+            }
+            Some("hotplug_memory") => {
+                let mem_cfg = MemDeviceConfigInfo {
+                    mem_id: "virtio-mem0".to_string(),
+                    capacity_mib: 0,
+                    size_mib: v["size_mib"]
+                        .as_u64()
+                        .context("Invalid virtio-mem size input")?,
+                    multi_region: true,
+                    host_numa_node_id: None,
+                    guest_numa_node_id: None,
+                    use_generic_irq: None,
+                    use_shared_irq: None,
+                };
+                return self.insert_mem_device(mem_cfg);
             }
             _ => {
                 println!("Unknown Actions");

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -305,4 +305,12 @@ The type of it is an array of BlockDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub hotplug_memory: Option<usize>,
+
+    #[clap(
+        long,
+        value_parser,
+        help = "Balloon memory (MiB) through connection with dbs-cli api server",
+        display_order = 2
+    )]
+    pub balloon_memory: Option<usize>,
 }

--- a/src/parser/args.rs
+++ b/src/parser/args.rs
@@ -297,4 +297,12 @@ The type of it is an array of BlockDeviceConfigInfo, e.g.
         display_order = 2
     )]
     pub hotplug_virblks: Option<String>,
+
+    #[clap(
+        long,
+        value_parser,
+        help = "Hotplug memory (MiB) through connection with dbs-cli api server",
+        display_order = 2
+    )]
+    pub hotplug_memory: Option<usize>,
 }

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -9,6 +9,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, VmmAction, VmmActionError, VmmData, VmmRequest,
         VmmResponse, VsockDeviceConfigInfo,
     },
+    device_manager::mem_dev_mgr::MemDeviceConfigInfo,
     device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vcpu::VcpuResizeInfo,
     vm::VmConfigInfo,
@@ -143,6 +144,12 @@ pub trait VMMComm {
     fn insert_virblk(&self, blk_cfg: BlockDeviceConfigInfo) -> Result<()> {
         self.handle_request(Request::Sync(VmmAction::InsertBlockDevice(blk_cfg.clone())))
             .with_context(|| format!("Failed to insert virtio-blk device {:?}", blk_cfg))?;
+        Ok(())
+    }
+    
+    fn insert_mem_device(&self, mem_cfg: MemDeviceConfigInfo) -> Result<()> {
+        self.handle_request_with_retry(Request::Sync(VmmAction::InsertMemDevice(mem_cfg.clone())))
+            .with_context(|| format!("Failed to insert mem device {:?}", mem_cfg))?;
         Ok(())
     }
 }

--- a/src/vmm_comm_trait.rs
+++ b/src/vmm_comm_trait.rs
@@ -9,6 +9,7 @@ use dragonball::{
         BlockDeviceConfigInfo, BootSourceConfig, VmmAction, VmmActionError, VmmData, VmmRequest,
         VmmResponse, VsockDeviceConfigInfo,
     },
+    device_manager::balloon_dev_mgr::BalloonDeviceConfigInfo,
     device_manager::mem_dev_mgr::MemDeviceConfigInfo,
     device_manager::virtio_net_dev_mgr::VirtioNetDeviceConfigInfo,
     vcpu::VcpuResizeInfo,
@@ -146,10 +147,18 @@ pub trait VMMComm {
             .with_context(|| format!("Failed to insert virtio-blk device {:?}", blk_cfg))?;
         Ok(())
     }
-    
+
     fn insert_mem_device(&self, mem_cfg: MemDeviceConfigInfo) -> Result<()> {
         self.handle_request_with_retry(Request::Sync(VmmAction::InsertMemDevice(mem_cfg.clone())))
             .with_context(|| format!("Failed to insert mem device {:?}", mem_cfg))?;
+        Ok(())
+    }
+
+    fn insert_balloon_device(&self, balloon_cfg: BalloonDeviceConfigInfo) -> Result<()> {
+        self.handle_request_with_retry(Request::Sync(VmmAction::InsertBalloonDevice(
+            balloon_cfg.clone(),
+        )))
+        .with_context(|| format!("Failed to insert balloon device {:?}", balloon_cfg))?;
         Ok(())
     }
 }


### PR DESCRIPTION
    dbs-cli: support virtio-balloon feature

    We can use dbs-cli to simply reuse unused virtual machine on host. An
    empty virtio-balloon device should be inserted first before we ask guest
    to balloon some free memory. It should use update action, and only
    parameter is size in mib.

    Example:

    First time:
    ./dbs-cli  --api-sock-path /tmp/api-sock --balloon-memory 0 update

    Next:
    ./dbs-cli  --api-sock-path /tmp/api-sock --balloon-memory 512 update

    Fixes: #23

    Signed-off-by: Helin Guo <helinguo@linux.alibaba.com>

----

    dbs-cli: support virtio-mem feature

    We can use dbs-cli to simply hotplug memory in virtual machine. It
    should use update action, and only parameter is size in mib.

    Example:

    ./dbs-cli  --api-sock-path /tmp/api-sock --hotplug-memory 1024 update

    Fixes: #23

    Signed-off-by: Helin Guo <helinguo@linux.alibaba.com>